### PR TITLE
add support for nullable()

### DIFF
--- a/sqlite3pp/sqlite3pp.hpp
+++ b/sqlite3pp/sqlite3pp.hpp
@@ -44,7 +44,7 @@ namespace sqlite3pp
     template <class T>
     class nullable_wrapper
     {
-        mutable T& val_;
+        T& val_;
         const T& null_value_;
     public:
         explicit nullable_wrapper(T& val, const T& null_value) : val_(val), null_value_(null_value) {}


### PR DESCRIPTION
Currently, the `get()` method and therefore the stream redirect methods throw an exception if a null value is fetched. This forces lots of boilerplate code using `(column_type(idx) == SQLITE_NULL)` logic. For example, consider the case with 3 columns: `present` which is nullable, `name` which is not null and `status` which is also nullable. Then a nice and fluid statement like this one

```
bool present;
string name, status;
for (; it != itEnd; ++it) {
    it->getter() >> present >> name >> status;
}
```

does not work since exceptions are thrown when null is encountered. So the code becomes

```
bool present;
string name, status;
for (; it != itEnd; ++it) {
    present = (it->column_type(0) == SQLITE_NULL) ? false : it->get<bool>(0);
    name = it->get<string>(1);
    status = (it->column_type(2) == SQLITE_NULL) ? "" : it->get<string>(2);
}
```

(other equally verbose implementations may use ugly try-catch constructs too).

This patch will add support for a `nullable()` function that allows to write the same fluid code above in a null-safe way:

```
bool present;
string name, status;
for (; it != itEnd; ++it) {
    it->getter() >> nullable(present, false) >> name >> nullable(status, "");
}
```

The patch also adds a `get_nullable()` function similar to `get()`.
